### PR TITLE
Add line breaks to ReBooked text in CampusNavbar

### DIFF
--- a/src/components/CampusNavbar.tsx
+++ b/src/components/CampusNavbar.tsx
@@ -60,7 +60,9 @@ const CampusNavbar = () => {
                 ReBooked Campus
               </span>
               <span className="text-sm font-bold text-book-600 xs:hidden">
-                ReBooked
+                ReBooked&nbsp;
+                <br />
+                <br />
               </span>
             </button>
           </div>


### PR DESCRIPTION
Adds a non-breaking space and two line breaks after "ReBooked" text in the CampusNavbar component.

Changes made:
- Added `&nbsp;` after "ReBooked" text
- Added two `<br />` elements for vertical spacing
- Only affects the small screen variant (xs:hidden class)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`

🔗 [Edit in Builder.io](https://builder.io/app/projects/122f20f1fd40444ab160f1c587187291/swoosh-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>122f20f1fd40444ab160f1c587187291</projectId>-->
<!--<branchName>swoosh-haven</branchName>-->