### PR TITLE
Fix regex patterns in vercel.json headers config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -21,7 +21,7 @@
       ]
     },
     {
-      "source": "/(.*\\.(js|css))",
+      "source": "/(.*)\\.(js|css)",
       "headers": [
         {
           "key": "Cache-Control",

--- a/vercel.json
+++ b/vercel.json
@@ -30,7 +30,7 @@
       ]
     },
     {
-      "source": "/(.*\\.(png|jpg|jpeg|gif|webp|svg|ico))",
+      "source": "/(.*)\\.(png|jpg|jpeg|gif|webp|svg|ico)",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
Updates regex patterns in vercel.json header configuration:

- Removes extra parentheses from JS/CSS file pattern: `/(.*\.(js|css))` → `/(.*)\\.(js|css)`
- Removes extra parentheses from image file pattern: `/(.*\.(png|jpg|jpeg|gif|webp|svg|ico))` → `/(.*)\\.(png|jpg|jpeg|gif|webp|svg|ico)`

These changes correct the regex syntax for matching static asset file extensions in the cache control headers configuration.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/774cd0850cbe4cd5906789961dec5eea/quantum-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>774cd0850cbe4cd5906789961dec5eea</projectId>-->
<!--<branchName>quantum-oasis</branchName>-->