### PR TITLE
Refactor React imports to use named imports

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-const {
+import React, {
   createContext,
   useContext,
   useEffect,
@@ -8,7 +7,7 @@ const {
   useMemo,
   useRef,
   startTransition,
-} = React;
+} from "react";
 import { User, Session } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 import {

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-const { createContext, useContext, useState, useEffect } = React;
+import React, { createContext, useContext, useState, useEffect } from "react";
 import { CartItem, CartContextType } from "@/types/cart";
 import { Book } from "@/types/book";
 import { toast } from "sonner";

--- a/src/contexts/GoogleMapsContext.tsx
+++ b/src/contexts/GoogleMapsContext.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-const { createContext, useContext } = React;
+import React, { createContext, useContext } from "react";
 type ReactNode = React.ReactNode;
 import { useJsApiLoader } from "@react-google-maps/api";
 


### PR DESCRIPTION
Updates React import statements across context files to use direct named imports instead of namespace imports with destructuring.

Changes made:
- AuthContext.tsx: Changed from `import * as React` with destructuring to `import React, { ... }` 
- CartContext.tsx: Changed from `import * as React` with destructuring to `import React, { ... }`
- GoogleMapsContext.tsx: Changed from `import * as React` with destructuring to `import React, { ... }`

This standardizes the import pattern across the codebase and simplifies the import statements.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 47`

🔗 [Edit in Builder.io](https://builder.io/app/projects/53d3fdfa33af442ab9b5c4eb0e209e2c/swoosh-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>53d3fdfa33af442ab9b5c4eb0e209e2c</projectId>-->
<!--<branchName>swoosh-garden</branchName>-->