### PR TITLE
Enable source maps for all build modes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -136,8 +136,8 @@ export default defineConfig(({ mode }) => ({
     },
     // Optimize chunk size warning limit
     chunkSizeWarningLimit: 500,
-    // Enable source maps for debugging in dev
-    sourcemap: mode === "development",
+    // Enable source maps for debugging
+    sourcemap: true,
     // Minify in production
     minify: mode === "production" ? "esbuild" : false,
     // Target modern browsers for better performance


### PR DESCRIPTION
Changes the sourcemap configuration in vite.config.ts from being enabled only in development mode to being enabled for all build modes.

- Changed `sourcemap: mode === "development"` to `sourcemap: true`
- Updated comment from "Enable source maps for debugging in dev" to "Enable source maps for debugging"

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 63`

🔗 [Edit in Builder.io](https://builder.io/app/projects/13013a32b61246d88fd38fa563b6ab1e/stellar-studio)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>13013a32b61246d88fd38fa563b6ab1e</projectId>-->
<!--<branchName>stellar-studio</branchName>-->