### PR TITLE
Downgrade Node.js runtime from 20.x to 18.x in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.ts": {
-      "runtime": "@vercel/node@3",
+      "runtime": "nodejs18.x",
       "maxDuration": 15
     }
   },

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.ts": {
-      "runtime": "nodejs20.x",
+      "runtime": "@vercel/node@3",
       "maxDuration": 15
     }
   },


### PR DESCRIPTION
Changes the Node.js runtime version from nodejs20.x to nodejs18.x for API functions in the Vercel configuration.

This affects all TypeScript files in the api directory and subdirectories.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 97`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2c424b21658f4b6896f888f80d5ab554/echo-home)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2c424b21658f4b6896f888f80d5ab554</projectId>-->
<!--<branchName>echo-home</branchName>-->