### PR TITLE
Add vercel.live to frame-src in Content-Security-Policy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -56,7 +56,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.paystack.co https://maps.googleapis.com https://cdn.gpteng.co https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://paystack.com; img-src 'self' data: https: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://kbpjqzaqbqukutflwixf.supabase.co https://api.paystack.co https://maps.googleapis.com wss://kbpjqzaqbqukutflwixf.supabase.co https://vercel.live; frame-src 'self' https://js.paystack.co https://checkout.paystack.com;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.paystack.co https://maps.googleapis.com https://cdn.gpteng.co https://vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://paystack.com; img-src 'self' data: https: blob:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://kbpjqzaqbqukutflwixf.supabase.co https://api.paystack.co https://maps.googleapis.com wss://kbpjqzaqbqukutflwixf.supabase.co https://vercel.live; frame-src 'self' https://js.paystack.co https://checkout.paystack.com https://vercel.live;"
         },
         {
           "key": "Strict-Transport-Security",


### PR DESCRIPTION
Updates the Content-Security-Policy header in vercel.json to include https://vercel.live in the frame-src directive.

The frame-src directive now allows:
- 'self'
- https://js.paystack.co
- https://checkout.paystack.com
- https://vercel.live (added)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 110`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b95ff2ef6eb54fa281fc49ff834bcddd/zenith-oasis)

👀 [Preview Link](https://b95ff2ef6eb54fa281fc49ff834bcddd-zenith-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b95ff2ef6eb54fa281fc49ff834bcddd</projectId>-->
<!--<branchName>zenith-oasis</branchName>-->