### PR TITLE
Downgrade @react-google-maps/api to v2.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -894,17 +894,22 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
     "node_modules/@googlemaps/js-api-loader": {
-      "version": "1.16.8",
-      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
-      "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.15.1.tgz",
+      "integrity": "sha512-AsnEgNsB7S/VdrHGEQUaUM2e5tmjFGKBAfzR/AqO8O7TPq/jQGvoRw5liPBw4EMF38RDsHmKDV89q/X+qiUREQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
     },
     "node_modules/@googlemaps/markerclusterer": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.5.3.tgz",
-      "integrity": "sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.0.13.tgz",
+      "integrity": "sha512-302GjQ9gsHOK/ef6hif+rJDv+AB3THst02iDCbXH2PS9GFwb/5yuytaLpuzJiqGNG+k2zvTAWTsGY/fQN5DZ7w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
-        "supercluster": "^8.0.1"
+        "supercluster": "^7.1.3"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -2391,31 +2396,34 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
     },
     "node_modules/@react-google-maps/api": {
-      "version": "2.20.7",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.20.7.tgz",
-      "integrity": "sha512-ys7uri3V6gjhYZUI43srHzSKDC6/jiKTwHNlwXFTvjeaJE3M3OaYBt9FZKvJs8qnOhL6i6nD1BKJoi1KrnkCkg==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.17.1.tgz",
+      "integrity": "sha512-XesubSCFfyMtilqljF2kU5zdPru4nks4I4O0HH6H2xOw51wQXs26btJKlRac2/jbJ/gIiGZ/l14q0xaL/6OaBg==",
+      "license": "MIT",
       "dependencies": {
-        "@googlemaps/js-api-loader": "1.16.8",
-        "@googlemaps/markerclusterer": "2.5.3",
-        "@react-google-maps/infobox": "2.20.0",
-        "@react-google-maps/marker-clusterer": "2.20.0",
-        "@types/google.maps": "3.58.1",
+        "@googlemaps/js-api-loader": "1.15.1",
+        "@googlemaps/markerclusterer": "2.0.13",
+        "@react-google-maps/infobox": "2.16.0",
+        "@react-google-maps/marker-clusterer": "2.16.1",
+        "@types/google.maps": "3.50.5",
         "invariant": "2.2.4"
       },
       "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19"
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@react-google-maps/infobox": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.20.0.tgz",
-      "integrity": "sha512-03PJHjohhaVLkX6+NHhlr8CIlvUxWaXhryqDjyaZ8iIqqix/nV8GFdz9O3m5OsjtxtNho09F/15j14yV0nuyLQ=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.16.0.tgz",
+      "integrity": "sha512-ZojiMS25388RcUHQPycUAerSqdHDom+3dHczVcXHdT/i8fka3O8InkHxXwMhvBoM143ips7mv2BPaYOAJ5f4Nw==",
+      "license": "MIT"
     },
     "node_modules/@react-google-maps/marker-clusterer": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz",
-      "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw=="
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.16.1.tgz",
+      "integrity": "sha512-jOuyqzWLeXvQcoAu6TCVWHAuko+sDt0JjawNHBGqUNLywMtTCvYP0L0PiqJZOUCUeRYGdUy0AKxQ+30vAkvwag==",
+      "license": "MIT"
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
@@ -3101,9 +3109,10 @@
       }
     },
     "node_modules/@types/google.maps": {
-      "version": "3.58.1",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
-      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ=="
+      "version": "3.50.5",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.50.5.tgz",
+      "integrity": "sha512-RuZf1MJtctGlpW+Gd4a/eGtAufUDjMf+eyN1l+B3fbe2YLScJbg8KEljJfb+6vnSPFAeM1/48geVIEg3vqOkxw==",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -5052,9 +5061,10 @@
       }
     },
     "node_modules/kdbush": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
-      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -6219,11 +6229,12 @@
       }
     },
     "node_modules/supercluster": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
-      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "license": "ISC",
       "dependencies": {
-        "kdbush": "^4.0.2"
+        "kdbush": "^3.0.0"
       }
     },
     "node_modules/supports-color": {

--- a/src/components/GoogleMapsAddressInput.tsx
+++ b/src/components/GoogleMapsAddressInput.tsx
@@ -1,9 +1,13 @@
 import { useRef, useState, useCallback } from "react";
-import { Autocomplete, GoogleMap, Marker } from "@react-google-maps/api";
+import {
+  Autocomplete,
+  GoogleMap,
+  Marker,
+  useLoadScript,
+} from "@react-google-maps/api";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MapPin, Loader2 } from "lucide-react";
-import { useGoogleMaps } from "@/contexts/GoogleMapsContext";
 
 const mapContainerStyle = { width: "100%", height: "300px" };
 

--- a/src/components/GoogleMapsAddressInput.tsx
+++ b/src/components/GoogleMapsAddressInput.tsx
@@ -44,7 +44,11 @@ const GoogleMapsAddressInput = ({
   className = "",
   defaultValue = "",
 }: GoogleMapsAddressInputProps) => {
-  const { isLoaded } = useGoogleMaps();
+  const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+  const { isLoaded } = useLoadScript({
+    googleMapsApiKey: apiKey || "",
+    libraries: ["places"],
+  });
   const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null);
   const [address, setAddress] = useState(defaultValue || "");
   const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(

--- a/src/components/checkout/EnhancedShippingForm.tsx
+++ b/src/components/checkout/EnhancedShippingForm.tsx
@@ -86,7 +86,11 @@ const EnhancedShippingForm: React.FC<EnhancedShippingFormProps> = ({
   cartItems,
 }) => {
   // All hooks must be called before any early returns
-  const { isLoaded } = useGoogleMaps();
+  const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+  const { isLoaded } = useLoadScript({
+    googleMapsApiKey: apiKey || "",
+    libraries: ["places"],
+  });
   const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null);
   const addressInputRef = useRef<HTMLInputElement>(null);
 

--- a/src/components/checkout/EnhancedShippingForm.tsx
+++ b/src/components/checkout/EnhancedShippingForm.tsx
@@ -27,7 +27,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
-import { useGoogleMaps } from "@/contexts/GoogleMapsContext";
+import { useLoadScript } from "@react-google-maps/api";
 import {
   getEnhancedDeliveryQuotes,
   validateSellersHaveAddresses,

--- a/src/components/examples/MapConsumerComponent.tsx
+++ b/src/components/examples/MapConsumerComponent.tsx
@@ -1,0 +1,37 @@
+import { GoogleMap, LoadScript, useGoogleMap } from "@react-google-maps/api";
+
+// Example MapConsumerComponent that properly uses useGoogleMap hook
+function MapConsumerComponent() {
+  const map = useGoogleMap();
+  console.log("Google Map:", map);
+
+  return null;
+}
+
+// Example of proper Google Maps usage following the guidelines
+const GoogleMapsExample = () => {
+  const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+
+  if (!apiKey) {
+    return (
+      <div className="p-4 border border-red-200 rounded-lg bg-red-50">
+        <p className="text-red-600">Google Maps API key not configured</p>
+      </div>
+    );
+  }
+
+  return (
+    <LoadScript googleMapsApiKey={apiKey}>
+      <GoogleMap
+        id="map"
+        center={{ lat: -25.746, lng: 28.188 }}
+        zoom={10}
+        mapContainerStyle={{ width: "100%", height: "400px" }}
+      >
+        <MapConsumerComponent />
+      </GoogleMap>
+    </LoadScript>
+  );
+};
+
+export default GoogleMapsExample;

--- a/src/contexts/GoogleMapsContext.tsx
+++ b/src/contexts/GoogleMapsContext.tsx
@@ -1,49 +1,23 @@
-import React, { useContext, createContext } from "react";
+import React from "react";
+import { LoadScript } from "@react-google-maps/api";
+
 type ReactNode = React.ReactNode;
-import { useJsApiLoader } from "@react-google-maps/api";
+
 // Define the libraries array with proper typing
 const libraries: "places"[] = ["places"];
-
-// Define the context type
-interface GoogleMapsContextType {
-  isLoaded: boolean;
-  loadError: Error | undefined;
-}
-
-// Create the context with undefined as default
-const GoogleMapsContext = createContext<GoogleMapsContextType | undefined>(
-  undefined,
-);
-
-// Custom hook to use the Google Maps context
-export const useGoogleMaps = (): GoogleMapsContextType => {
-  const context = useContext(GoogleMapsContext);
-  if (context === undefined) {
-    throw new Error("useGoogleMaps must be used within a GoogleMapsProvider");
-  }
-  return context;
-};
 
 // Provider props interface
 interface GoogleMapsProviderProps {
   children: ReactNode;
 }
 
-// Google Maps Provider component
+// Google Maps Provider component using LoadScript
 export const GoogleMapsProvider: React.FC<GoogleMapsProviderProps> = ({
   children,
 }) => {
   // Skip Google Maps loading in non-browser environments
   if (typeof window === "undefined") {
-    const mockContext: GoogleMapsContextType = {
-      isLoaded: false,
-      loadError: undefined,
-    };
-    return (
-      <GoogleMapsContext.Provider value={mockContext}>
-        {children}
-      </GoogleMapsContext.Provider>
-    );
+    return <>{children}</>;
   }
 
   const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
@@ -52,27 +26,6 @@ export const GoogleMapsProvider: React.FC<GoogleMapsProviderProps> = ({
   const isBrowser =
     typeof window !== "undefined" && typeof document !== "undefined";
   const hasApiKey = Boolean(apiKey && apiKey.trim() !== "" && isBrowser);
-
-  // Always call useJsApiLoader hook - React hooks must be called unconditionally
-  const { isLoaded, loadError } = useJsApiLoader({
-    id: "google-map-script",
-    googleMapsApiKey: apiKey || "",
-    libraries,
-    preventGoogleFontsLoading: true,
-    // Skip loading if no API key or not in browser
-    skipApiLoad: !hasApiKey || !isBrowser,
-  });
-
-  // Provide fallback state for non-browser or no API key
-  const value: GoogleMapsContextType = {
-    isLoaded: hasApiKey && isBrowser ? isLoaded : false,
-    loadError:
-      hasApiKey && isBrowser
-        ? loadError
-        : isBrowser
-          ? new Error("Google Maps API key not configured")
-          : new Error("Google Maps not available in Workers environment"),
-  };
 
   // Log warning in development
   if (!hasApiKey && import.meta.env.DEV) {
@@ -83,12 +36,17 @@ export const GoogleMapsProvider: React.FC<GoogleMapsProviderProps> = ({
         "2. Add VITE_GOOGLE_MAPS_API_KEY=your_api_key to your .env file\n" +
         "3. Enable Places API in Google Cloud Console",
     );
+    return <>{children}</>;
   }
 
   return (
-    <GoogleMapsContext.Provider value={value}>
+    <LoadScript
+      googleMapsApiKey={apiKey || ""}
+      libraries={libraries}
+      preventGoogleFontsLoading={true}
+    >
       {children}
-    </GoogleMapsContext.Provider>
+    </LoadScript>
   );
 };
 


### PR DESCRIPTION
Downgrade @react-google-maps/api from v2.20.7 to v2.17.1 and related dependencies.

Package version changes:
- @react-google-maps/api: 2.20.7 → 2.17.1
- @googlemaps/js-api-loader: 1.16.8 → 1.15.1
- @googlemaps/markerclusterer: 2.5.3 → 2.0.13
- @react-google-maps/infobox: 2.20.0 → 2.16.0
- @react-google-maps/marker-clusterer: 2.20.0 → 2.16.1
- @types/google.maps: 3.58.1 → 3.50.5
- supercluster: 8.0.1 → 7.1.5
- kdbush: 4.0.2 → 3.0.0

Code changes:
- Replace useGoogleMaps context with useLoadScript hook in GoogleMapsAddressInput and EnhancedShippingForm
- Refactor GoogleMapsContext to use LoadScript component instead of useJsApiLoader
- Add example MapConsumerComponent demonstrating proper Google Maps usage
- Update peer dependency requirements for React (removed v19 support)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 139`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7ac1e06e644a42e7a0bdd0ee9509f3aa/mystic-lab)

👀 [Preview Link](https://7ac1e06e644a42e7a0bdd0ee9509f3aa-mystic-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7ac1e06e644a42e7a0bdd0ee9509f3aa</projectId>-->
<!--<branchName>mystic-lab</branchName>-->